### PR TITLE
Performance fixes

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -44,7 +44,7 @@ fi
 
 DIR=${SRC_DIR##*/}
 echo $DIR 1>&2
-REFS=$(ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER "find $SRC_DIR -type f -exec stat -c '%Y' {} \; | sort -n | tail -1")
+REFS=$(ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER "find $SRC_DIR -type f -printf '%T@\n' | cut -d. -f1 | sort -n | tail -1")
 if [ "$?" -eq "0" ]
 then
     REFS="[{ \"ref\": \"$REFS\" }]"

--- a/assets/check
+++ b/assets/check
@@ -2,6 +2,14 @@
 
 set -e -x
 
+function stop_ssh_agent()
+{
+    [ ! -z "$SSH_AGENT_PID" ] && kill $SSH_AGENT_PID
+}
+
+trap stop_ssh_agent EXIT
+trap stop_ssh_agent SIGINT SIGTERM
+
 SCRIPT_INPUT='/tmp/input'
 cat > $SCRIPT_INPUT <&0 # STDIN params
 

--- a/assets/in
+++ b/assets/in
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function stop_ssh_agent()
+{
+    [ ! -z "$SSH_AGENT_PID" ] && kill $SSH_AGENT_PID
+}
+
+trap stop_ssh_agent EXIT
+trap stop_ssh_agent SIGINT SIGTERM
+
 DEST_DIR=$1
 echo $SRC_DIR 1>&2
 echo $BUILD_ID 1>&2

--- a/assets/in
+++ b/assets/in
@@ -81,7 +81,7 @@ if [ "$skip_download" = "false" ]; then
         eval $RSYNC_CMD  1>&2
 
         if [ $? -eq 0 ]; then
-            TIMESTAMP=$(find $DEST_DIR -type f -exec stat -c "%Y" {} \; | sort -n | tail -1)
+            TIMESTAMP=$(find $DEST_DIR -type f -printf '%T@\n' | cut -d. -f1 | sort -n | tail -1)
             OUTPUT_STRING="{ \"version\": { \"ref\": \"$TIMESTAMP\"} }"
             echo $OUTPUT_STRING
             exit 0
@@ -91,7 +91,7 @@ if [ "$skip_download" = "false" ]; then
         while [ $? -ne 0 -a $i -lt $MAX_RETRIES ]
         do
             if [ $? -eq 0 ]; then
-                TIMESTAMP=$(find $DEST_DIR -type f -exec stat -c "%Y" {} \; | sort -n | tail -1)
+                TIMESTAMP=$(find $DEST_DIR -type f -printf '%T@\n' | cut -d. -f1 | sort -n | tail -1)
                 OUTPUT_STRING="{ \"version\": { \"ref\": \"$TIMESTAMP\"} }"
                 echo $OUTPUT_STRING
                 exit 0

--- a/assets/out
+++ b/assets/out
@@ -37,7 +37,7 @@ jq -re '.source.version_ref' < $SCRIPT_INPUT >/dev/null
 if [ $? -eq 1 ]; then
     # next best thing is timestamp of latest file
     echo "No version ref found in parameters; using latest timestamp" 1>&2
-    VERSION_REF=$(find "$SRC_DIR/$SYNC_DIR" -type f -exec stat -c "%Y" {} \; | sort -n | tail -1)
+    VERSION_REF=$(find "$SRC_DIR/$SYNC_DIR" -type f -printf '%T@\n' | cut -d. -f1 | sort -n | tail -1)
 else
     VERSION_REF=$(jq -re '.source.version_ref // ""' < $SCRIPT_INPUT)
     echo "Found version_ref in params.  Value: ${VERSION_REF}" 1>&2

--- a/assets/out
+++ b/assets/out
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function stop_ssh_agent()
+{
+    [ ! -z "$SSH_AGENT_PID" ] && kill $SSH_AGENT_PID
+}
+
+trap stop_ssh_agent EXIT
+trap stop_ssh_agent SIGINT SIGTERM
+
 SRC_DIR=$1
 echo $SRC_DIR 1>&2
 echo $BUILD_ID 1>&2


### PR DESCRIPTION
* Replace `-exec stat` with `-print` to avoid excessive I/O load on destination system.
* Clean up `ssh-agent` when exiting so we don't leave stray processes around.